### PR TITLE
Unit tests and TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "node"
+  - "8"
+
+install:
+  - npm install
+
+script:
+  - npm test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "8"
 
 install:
   - npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decorator-wrapper",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1063,6 +1063,12 @@
         "repeat-element": "1.1.2"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1368,6 +1374,12 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -1975,7 +1987,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -2524,6 +2537,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2598,6 +2617,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3106,6 +3131,56 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "nodemon -w test --exec \"babel-node test\"",
-    "build": "babel src -s -D -d dist"
+    "build": "babel src -s -D -d dist",
+    "test": "mocha --require babel-core/register"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
+    "mocha": "^5.0.1",
     "nodemon": "^1.15.0"
   }
 }

--- a/src/classDecoration.js
+++ b/src/classDecoration.js
@@ -1,11 +1,14 @@
 export default (target, key, descriptor, decoratorInstance, decoratorArgs) => {
     let createInstance = (...args) => new target(...args);
     decoratorInstance.classDefined(target.name, createInstance, decoratorArgs);
-    return (...args) => {
+    let wrapped_type = (...args) => {
         let instance = decoratorInstance.classInstanced(target.name, args, createInstance, decoratorArgs);
         if (typeof instance === 'undefined') {
             instance = new target(...args);
         }
         return instance;
     };
+    
+    wrapped_type.prototype = target.prototype; // making sure 'instanceof' recognizes the object type
+    return wrapped_type;
 }

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -238,7 +238,7 @@ describe('Test Method Decorator', function(){
     
   });
   
-  it('method decorator argument are correct', function(){
+  it('method decorator arguments are correct', function(){
     let dmethod = undefined, 
         dmethodName = undefined, 
         dargNames = undefined, 
@@ -260,9 +260,110 @@ describe('Test Method Decorator', function(){
       foo(strVal, numVal){}
     }
     
-    new AClass().foo('forty', 2)
+    let inst = new AClass();
+    inst.foo('forty', 2);
     
     
+    assert.ok(dmethod, 'Method reference was not passed to the decorator.');
+    assert.equal(dmethodName, 'foo', 'Expected to get the correct method name "foo", but instead got ' + dmethodName);
+    assert.ok(dargNames, 'Method argument names were not passed to the decorator.');
+    
+    assert.equal(dargNames.length, 2, 'Expected to get 2 argument names, but instead got ' + dargNames.length);
+    assert.equal(dargNames[0], 'strVal', 'Expected to get "strVal" for the first argument name. Instead got ' + dargNames[0]);
+    assert.equal(dargNames[1], 'numVal', 'Expected to get "numVal" for the second argument name. Instead got ' + dargNames[1]);
+    
+    assert.ok(dscope, 'Method scope was not passed');
+    assert.equal(inst, dscope, 'Expected to get ' + inst + ' as method scope, but instead got ' + dscope);
+  });
+  
+  it('should be able to pass a value to the method decorator', function(){
+    let dval = undefined;
+    
+    class ClassDecorator extends DummyDecorator {
+      methodCalled(method, methodName, args, argNames, scope, [ value ]) {
+        dval = value;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator('flag')
+      foo(){ }
+    }
+    
+    new AClass().foo();
+    
+    assert.ok(dval, 'Decorator argument was not passed to the decorator handler.');
+    assert.equal(dval, 'flag', 'Expected to get "flag" for the decorator argument value, but instead got ' + dval);
   });
   
 });
+
+describe('Test Property Decorator', function(){
+  it('property decorator should be called', function(){
+    let called = undefined;
+    class ClassDecorator extends DummyDecorator {
+      propertyInit(propertyName, descriptor) {
+        called = true;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator
+      foo = 9000
+    }
+    
+    new AClass();
+    
+    assert.ok(called, 'Property decorator was not called.');
+  });
+  
+  it('property name should be passed to the decorator handler', function(){
+    let pname = undefined;
+    class ClassDecorator extends DummyDecorator {
+      propertyInit(propertyName, descriptor) {
+        pname = propertyName;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator
+      foo = 9000
+    }
+    
+    new AClass();
+    
+    assert.ok(pname, 'Property name was not passed to the decorator handler');
+    assert.equal(pname, 'foo', 'Expected to get "foo" as the property name, but instead got ' + pname);
+  });
+  
+  it('should be able to pass an argument to the property decorator', function(){
+    let pval = undefined;
+    class ClassDecorator extends DummyDecorator {
+      propertyInit(propertyName, descriptor, [ value ]) {
+        pval = value;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator('over')
+      foo = 9000
+    }
+    
+    new AClass();
+    
+    assert.ok(pval, 'Decorator argument was not passed to the handler.');
+    assert.equal(pval, 'over', 'Expected to get "over" as decorator argument, but instead got ' + pval);
+  });
+  
+});
+
+
+

--- a/test/decorator.js
+++ b/test/decorator.js
@@ -1,0 +1,268 @@
+import { DECORATOR } from '../src';
+import assert from 'assert'
+
+class DummyDecorator {
+  classDefined(className, createInstance, [ testString ]) {
+  }
+
+  classInstanced(className, args, createInstance, [ testString ]) {
+
+  }
+
+  methodCalled(method, methodName, args, argNames, scope, [ exampleText ]) {
+
+  }
+
+  propertyInit(propertyName, descriptor, [ value ]) {
+  }
+}
+
+describe('Test Class Decorators', function(){
+  describe('Class Defined Decorator', function(){
+    it('class defined decorator should be called', function(){
+      let classDefinedCalled = false;
+      class ClassDecorator extends DummyDecorator {
+        classDefined(className, createInstance, [ testString ]) {
+          classDefinedCalled = true;
+        }
+      };
+
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator
+      class AClass {
+
+      }
+
+      assert.ok(classDefinedCalled, 'The decorator should\'ve been called, but it wasn\'t.');
+    });
+    
+    it('should be able to pass arg to the decorator', function(){
+      class ClassDecorator extends DummyDecorator {
+        classDefined(className, createInstance, [decoratorVal]){
+          assert.equal(decoratorVal, 'some-value', 'Expected to get "some-value" as decorator argument, but instead got: ' + decoratorVal);
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator("some-value")
+      class AClass {
+
+      }
+      
+    });
+    
+    it('should resolve class name properly', function(){
+      class ClassDecorator extends DummyDecorator {
+        classDefined(className, createInstance){
+          assert.equal(className, 'AClass', 'Expected to get "AClass" as class name, but instead got: ' + className);
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator()
+      class AClass {}
+    });
+    
+    it('should be able to create proper instance of the class', function(){
+      let instance = undefined;
+      
+      class ClassDecorator extends DummyDecorator {
+        classDefined(className, createInstance){
+          instance = createInstance();
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator()
+      class AClass {}
+      
+      assert.ok(instance, 'Expected to create a new instance.')
+      assert.ok(instance instanceof AClass, 'Expected the instance to be of class AClass, but instead is of type ' + (typeof instance));
+      
+    });
+  });
+  
+  describe('Class Instanced Decorator', function(){
+    it('class instanced decorator should be called', function(){
+      let decoratorCalled = false;
+      class ClassDecorator extends DummyDecorator {
+        classInstanced(className, args, createInstance) {
+          decoratorCalled = true;
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator()
+      class AClass {}
+      
+      new AClass()
+      
+      assert.ok(decoratorCalled, 'Expected the class instanced decorator to be called.')
+      
+    });
+    
+    it('should pass decorator arguments', function(){
+      class ClassDecorator extends DummyDecorator {
+        classInstanced(className, args, createInstance, [ value ]) {
+          assert.ok(value, 'decorator-value', 'Expected to get "decorator-value" in the decorator arguments, but instead got ' + value);
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator('decorator-value')
+      class AClass {}
+      
+      new AClass()
+      
+    });
+    
+    it('should pass correct class name and constructor args', function(){
+      let clsName = undefined;
+      let constrArgs = undefined;
+      
+      class ClassDecorator extends DummyDecorator {
+        classInstanced(className, args, createInstance) {
+          clsName = className;
+          constrArgs = args;
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator
+      class AClass {}
+      
+      new AClass('value0')
+      
+      assert.equal(clsName, 'AClass', 'Expected to get "AClass" as class name, but instad got ' + clsName);
+      assert.ok(constrArgs, 'Expected the constructor arguments to be passed to the decorator');
+      assert.ok(constrArgs.length, 'Expected to get at least one constructor argument');
+      assert.equal(constrArgs[0], 'value0', 'Expected to get "value0" for the constructor argument, but instead got ' + constrArgs[0]);
+    });
+    
+    
+    it('should create correct instances of the class type', function(){
+      let decoratorInstance = undefined;
+      class ClassDecorator extends DummyDecorator {
+        classInstanced(className, args, createInstance) {
+          decoratorInstance = createInstance();
+        }
+      }
+      
+      let decorator = DECORATOR(ClassDecorator);
+      
+      @decorator
+      class AClass {}
+      
+      let stdInstance = new AClass()
+      
+      assert.ok(decoratorInstance, 'An instance was not created with "createInstance".');
+      assert.ok(decoratorInstance instanceof AClass, 'Expected the instance created with "createInstance" to be of type "AClass", but instead it is of type ' + (typeof decoratorInstance));
+      
+      assert.ok(stdInstance instanceof AClass, 'Expected the instance created with "new AClass()" to be of type "AClass", but instead is of type ' + (typeof stdInstance));
+      
+      
+    });
+    
+  });
+});
+
+
+describe('Test Method Decorator', function(){
+  it('method decorator should be called', function(){
+    let called = false;
+    
+    class ClassDecorator extends DummyDecorator {
+      methodCalled(method, methodName, args, argNames, scope) {
+        called = true
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator
+      foo(){}
+    }
+    
+    new AClass().foo()
+    
+    assert.ok(called, 'The decorator was not called.');
+  });
+  
+  it('method decorator and the method itself should be called with correct arguments', function(){
+    let called = false;
+    let dargs = undefined;
+    
+    class ClassDecorator extends DummyDecorator {
+      methodCalled(method, methodName, args, argNames, scope) {
+        called = true;
+        dargs = args;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    let methodCalled = false;
+    let arg1 = undefined;
+    let arg2 = undefined;
+    
+    class AClass {
+      @decorator
+      foo(strVal, numVal){
+        methodCalled = true;
+        arg1 = strVal;
+        arg2 = numVal;
+      }
+    }
+    
+    new AClass().foo('over', 9000)
+    
+    assert.ok(called, 'The decorator was not called.');
+    assert.ok(dargs, 'Expected the method arguments to be passed to the decorator.')
+    assert.equal(dargs.length, 2, 'Expected exactly 2 arguments to be passed, but istead were passed ' + dargs.length);
+    assert.equal(dargs[0], 'over', 'Decorator got invalid value passed for the first argument of the method. Expected "over" but instead got ' + dargs[0]);
+    assert.equal(arg2, 9000, 'Decorator got invalid value passed for the second argument of the method. Expected 9000 but instead got ' + dargs[1]);
+    
+    
+    
+    assert.ok(methodCalled, 'The method was not actually called.')
+    assert.equal(arg1, 'over', 'Invalid value passed for the first argument of the method. Expected "over" but instead got ' + arg1);
+    assert.equal(arg2, 9000, 'Invalid value passed for the second argument of the method. Expected 9000 but instead got ' + arg2);
+    
+  });
+  
+  it('method decorator argument are correct', function(){
+    let dmethod = undefined, 
+        dmethodName = undefined, 
+        dargNames = undefined, 
+        dscope = undefined;
+    
+    class ClassDecorator extends DummyDecorator {
+      methodCalled(method, methodName, args, argNames, scope) {
+        dmethod = method;
+        dmethodName = methodName;
+        dargNames = argNames;
+        dscope = scope;
+      }
+    }
+    
+    let decorator = DECORATOR(ClassDecorator);
+    
+    class AClass {
+      @decorator
+      foo(strVal, numVal){}
+    }
+    
+    new AClass().foo('forty', 2)
+    
+    
+  });
+  
+});


### PR DESCRIPTION
This PR contains:

- Unit tests with Mocha for all decorator handlers (class defined, class instanced, method and property). Run with ```npm test```
- Fix for the instance created when using class decorator - the result instance of the class did not have the proper prototype causing ```instanceof``` to not work properly:
```!javascript
@classDecorator
class A{}

let obj = new A();
assert(obj instanceof A); // fails
```
Fixed by setting the proper prototype of the resulting instance.

- Added .travis.yml configured to run the unit tests. You can set up your repo on http://travis-ci.org/ and it will run the tests on every push.